### PR TITLE
Feature/match text to meme url

### DIFF
--- a/memeGeneration/handler.py
+++ b/memeGeneration/handler.py
@@ -2,7 +2,7 @@ from django.http.response import JsonResponse
 from rest_framework.response import Response
 import logging
 from .serializer import *
-from logtail import LogtailHandler
+from logtail.handler import LogtailHandler
 from datetime import datetime
 import openai
 import weaviate
@@ -12,11 +12,11 @@ from PIL import Image, ImageDraw, ImageFont
 
 
 
-handler = LogtailHandler(source_token="tvoi6AuG8ieLux2PbHqdJSVR")
-logger = logging.getLogger(__name__)
-logger.handlers = []
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+# handler = LogtailHandler(source_token="tvoi6AuG8ieLux2PbHqdJSVR")
+# logger = logging.getLogger(__name__)
+# logger.handlers = []
+# logger.addHandler(handler)
+# logger.setLevel(logging.INFO)
 
 WEAVIATE_URL = os.getenv('WEAVIATE_URL')
 CLIENT_CONFIG = None
@@ -69,8 +69,8 @@ def generate_text_for_meme(generateTextForMemeRequest):
       presence_penalty=0,
     )
 
-    logger.info("Meme input text: " + str(memeText))
-    logger.info("Meme text: " + str(memeText.choices[0].text))
+    # logger.info("Meme input text: " + str(memeText))
+    # logger.info("Meme text: " + str(memeText.choices[0].text))
 
     # Return the meme URL and description
     return GenerateTextForMemeResponse(

--- a/memeMatching/handler.py
+++ b/memeMatching/handler.py
@@ -80,6 +80,7 @@ def match_text_to_meme(matchTextToMemeRequest):
     )
 
     # logger.info("Meme query text: " + str(memeQueryText))
+    print("Meme query text: " + str(memeQueryText))
 
     # Use that text to match with memes
     source_text = { "concepts": memeQueryText.choices[0].text }

--- a/memeMatching/handler.py
+++ b/memeMatching/handler.py
@@ -2,7 +2,7 @@ from django.http.response import JsonResponse
 from rest_framework.response import Response
 import logging
 from .serializer import *
-from logtail import LogtailHandler
+from logtail.handler import LogtailHandler
 from datetime import datetime
 import openai
 import weaviate
@@ -12,11 +12,11 @@ from idl import *
 import requests
 import base64
 
-handler = LogtailHandler(source_token="tvoi6AuG8ieLux2PbHqdJSVR")
-logger = logging.getLogger(__name__)
-logger.handlers = []
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+# handler = LogtailHandler(source_token="tvoi6AuG8ieLux2PbHqdJSVR")
+# logger = logging.getLogger(__name__)
+# logger.handlers = []
+# logger.addHandler(handler)
+# logger.setLevel(logging.INFO)
 
 WEAVIATE_URL = os.getenv('WEAVIATE_URL')
 CLIENT_CONFIG = None
@@ -55,8 +55,8 @@ def hello_world(helloWorldRequest):
   """
     Demo function for testing purposes
   """
-  logger.info(helloWorldRequest)
-  logger.info(helloWorldRequest.name)
+  # logger.info(helloWorldRequest)
+  # logger.info(helloWorldRequest.name)
 
 
 def match_text_to_meme(matchTextToMemeRequest):
@@ -72,21 +72,22 @@ def match_text_to_meme(matchTextToMemeRequest):
       prompt=emotionalDescription,
       temperature=0.7,
       max_tokens=500,
-      n=10,
+      n=1,
       stop=None,
       frequency_penalty=0,
       best_of=1,
       presence_penalty=0,
     )
 
-    logger.info("Meme query text: " + str(memeQueryText))
+    # logger.info("Meme query text: " + str(memeQueryText))
 
     # Use that text to match with memes
     source_text = { "concepts": memeQueryText.choices[0].text }
 
-    weaviate_results = CLIENT.query.get("Meme", ["description", 'image']).with_near_text(source_text).with_limit(10).do()
+    weaviate_results = CLIENT.query.get("Meme", [
+       'description', 'image', 'template_url']).with_near_text(source_text).with_limit(10).do()
 
-    logger.info("Weaviate results: " + str(weaviate_results))
+    # logger.info("Weaviate results: " + str(weaviate_results))
 
     # Return the meme URL and description
     return MatchTextToMemeResponse(
@@ -116,14 +117,14 @@ def index_memes_weaviate(indexMemesWeaviateRequest):
     b64_encoded_image = base64.b64encode(response.content).decode('utf-8')
 
     data_object = {
-      'filename': url,
-      'filepath': url,
+      'name': description.replace(' ', '-'),
+      'template_url': url,
       'description': description,
       'image': b64_encoded_image
       }
 
-    logger.info(f"Uploading meme found at {url} " \
-                f"with the following description: {description}")
+    # logger.info(f"Uploading meme found at {url} " \
+    #             f"with the following description: {description}")
 
     # Write image data to file to check if images are encoded correctly.
     # with open(f'image-uploaded-to-weaviate-{i}.png', 'wb') as f:
@@ -131,10 +132,10 @@ def index_memes_weaviate(indexMemesWeaviateRequest):
 
     try:
       CLIENT.batch.add_data_object(data_object, "Meme")
-      logger.info('Successfully added Meme object to batch!')
+      print(f'Successfully added Meme object {description} to batch!')
     except Exception as e:
        return IndexMemesWeaviateResponse(Error=str(e))
 
-  logger.info('Sending Meme objects to Weaviate')
+  # logger.info('Sending Meme objects to Weaviate')
   CLIENT.batch.flush()
   return IndexMemesWeaviateResponse(Error=None)

--- a/weaviate-schema/schema.json
+++ b/weaviate-schema/schema.json
@@ -20,8 +20,8 @@
                 },
                 {
                     "dataType": ["text"],
-                    "description": "Filename of meme",
-                    "name": "filename",
+                    "description": "URL of meme template",
+                    "name": "template_url",
                     "moduleConfig": {
                         "text2vec-openai": {
                             "skip": true
@@ -30,7 +30,7 @@
                 },
                 {
                     "dataType": ["text"],
-                    "description": "Name of meme",
+                    "description": "Name of Meme",
                     "name": "name",
                     "moduleConfig": {
                         "text2vec-openai": {

--- a/weaviate-schema/schema.json
+++ b/weaviate-schema/schema.json
@@ -24,7 +24,8 @@
                     "name": "template_url",
                     "moduleConfig": {
                         "text2vec-openai": {
-                            "skip": true
+                            "skip": true,
+                            "vectorizePropertyName": false
                         }
                     }
                 },
@@ -34,7 +35,8 @@
                     "name": "name",
                     "moduleConfig": {
                         "text2vec-openai": {
-                            "skip": true
+                            "skip": true,
+                            "vectorizePropertyName": false
                         }
                     }
                 },
@@ -44,7 +46,8 @@
                     "name": "image",
                     "moduleConfig": {
                         "text2vec-openai": {
-                            "skip": true
+                            "skip": true,
+                            "vectorizePropertyName": false
                         }
                     }
                 }


### PR DESCRIPTION
URL should now be added to response from match text to meme endpoint. 

Here's an example response:

```json
"{\"Memes\": [{\"description\": \"A sad person receiving some comfort\", \"image\": \"...\", \"template_url\": \"https://hlhmmkpugruknefsttlr.supabase.co/storage/v1/object/public/meme-templates-public/crying-boy-on-a-bench.png\"}, ...]}"
```

Also, I've currently disabled logging to LogtailHandler for now. Will re-add that back in once we adjust what we are logging.